### PR TITLE
Avoid dismissing when state is not draggable

### DIFF
--- a/Example/DraggableModalTransition/ViewController.swift
+++ b/Example/DraggableModalTransition/ViewController.swift
@@ -9,7 +9,7 @@ final class ViewController: UIViewController {
        
         let button: UIButton = {
             let button = UIButton()
-            button.setTitle("Pop", for: .normal)
+            button.setTitle("Present", for: .normal)
             button.setTitleColor(.white, for: .normal)
             button.sizeToFit()
             button.center = view.center

--- a/Sources/DraggableModalTransition.swift
+++ b/Sources/DraggableModalTransition.swift
@@ -71,7 +71,7 @@ public class DraggableModalTransition: UIPercentDrivenInteractiveTransition {
             guard dismissed else {
                 setupInteractiveTransition(atLocationY: location.y)
                 return
-            }            
+            }
             guard let fromViewController = transitionContext?.viewController(forKey: .from) else { return }
             
             if fromViewController.view.frame.origin.y <= 0 {


### PR DESCRIPTION
## WHY & WHAT

Previously `DraggableModalTransition` **always** dismisses view when `handlePanGesture` gets called, even if it will be cancelled later. This leads to unnecessary calls of view lifecycle methods.

Now view gets dismissed only when state is `draggable`.