### PR TITLE
Correct context handling

### DIFF
--- a/Sources/DraggableModalTransition.swift
+++ b/Sources/DraggableModalTransition.swift
@@ -134,16 +134,15 @@ public class DraggableModalTransition: UIPercentDrivenInteractiveTransition {
                 fromViewController.view.frame = targetRect
                 self.backgroundView.alpha = 0.0
         }, completion: { _ in
+            self.cleanUpTransition()
             let didCompleteTransition = !transitionContext.transitionWasCancelled
             transitionContext.completeTransition(didCompleteTransition)
-            self.cleanUpTransition()
             transitionContext.finishInteractiveTransition()
         })
     }
 
     override public func cancel() {
         guard let transitionContext = transitionContext else { return }
-        transitionContext.cancelInteractiveTransition()
         guard let fromViewController = transitionContext.viewController(forKey: .from) else { return }
         guard let toViewController = transitionContext.viewController(forKey: .to) else { return }
         
@@ -164,9 +163,10 @@ public class DraggableModalTransition: UIPercentDrivenInteractiveTransition {
                 fromViewController.view.frame = targetRect
                 self.backgroundView.alpha = 1.0
         }, completion: { _ in
-            transitionContext.completeTransition(false)
             toViewController.view.removeFromSuperview()
             self.cleanUpTransition()
+            transitionContext.completeTransition(false)
+            transitionContext.cancelInteractiveTransition()
         })
     }
 

--- a/Sources/DraggableModalTransition.swift
+++ b/Sources/DraggableModalTransition.swift
@@ -142,32 +142,37 @@ public class DraggableModalTransition: UIPercentDrivenInteractiveTransition {
     }
 
     override public func cancel() {
-        guard let transitionContext = transitionContext else { return }
-        guard let fromViewController = transitionContext.viewController(forKey: .from) else { return }
-        guard let toViewController = transitionContext.viewController(forKey: .to) else { return }
-        
         gestureRecognizerProxy?.isEnabled = false
-        let targetRect = CGRect(
-            x: 0,
-            y: 0,
-            width: fromViewController.view.bounds.width,
-            height: fromViewController.view.bounds.height
-        )
-        UIView.animate(
-            withDuration: TimeInterval(transitionDuration),
-            delay: 0,
-            usingSpringWithDamping: 0.8,
-            initialSpringVelocity: 0.1,
-            options: UIViewAnimationOptions.curveEaseOut,
-            animations: {
-                fromViewController.view.frame = targetRect
-                self.backgroundView.alpha = 1.0
-        }, completion: { _ in
-            toViewController.view.removeFromSuperview()
+        let completion = {
             self.cleanUpTransition()
-            transitionContext.completeTransition(false)
-            transitionContext.cancelInteractiveTransition()
-        })
+            self.transitionContext?.completeTransition(false)
+            self.transitionContext?.cancelInteractiveTransition()
+        }
+        
+        if let fromViewController = transitionContext?.viewController(forKey: .from),
+            let toViewController = transitionContext?.viewController(forKey: .to) {
+            let targetRect = CGRect(
+                x: 0,
+                y: 0,
+                width: fromViewController.view.bounds.width,
+                height: fromViewController.view.bounds.height
+            )
+            UIView.animate(
+                withDuration: TimeInterval(transitionDuration),
+                delay: 0,
+                usingSpringWithDamping: 0.8,
+                initialSpringVelocity: 0.1,
+                options: UIViewAnimationOptions.curveEaseOut,
+                animations: {
+                    fromViewController.view.frame = targetRect
+                    self.backgroundView.alpha = 1.0
+            }, completion: { _ in
+                toViewController.view.removeFromSuperview()
+                completion()
+            })
+        } else {
+            completion()
+        }
     }
 
     private func cleanUpTransition() {

--- a/Sources/DraggableModalTransition.swift
+++ b/Sources/DraggableModalTransition.swift
@@ -137,6 +137,7 @@ public class DraggableModalTransition: UIPercentDrivenInteractiveTransition {
             let didCompleteTransition = !transitionContext.transitionWasCancelled
             transitionContext.completeTransition(didCompleteTransition)
             self.cleanUpTransition()
+            transitionContext.finishInteractiveTransition()
         })
     }
 


### PR DESCRIPTION
## WHAT

* Call `finishInteractiveTransition`
* Fix order of context handling processes
* Enable cancelling even when transition context does not exist
  * Found that context does not exist in `cancel` depending on the usage.
